### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@master
 
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: tuckn/aws-cli-tokyo
         username: ${{ secrets.DOCKERHUB_USERNAME  }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore